### PR TITLE
Channels

### DIFF
--- a/Bedrock.Framework/Protocols/Protocol.cs
+++ b/Bedrock.Framework/Protocols/Protocol.cs
@@ -99,6 +99,7 @@ namespace Bedrock.Framework.Protocols
                         {
                             inputBuffer.Complete();
                         }
+                        break;
                     }
                 }
                 finally


### PR DESCRIPTION
missing: end the write loops at some point 

I didnt see a significant improvement in my benchmarks but it should perform better:

the idea is batching stuff a little:

read mutiple messages if possible before calling readasync again
write multiple messages before flushing the buffer 

