### PR TITLE
split reader and writer

### DIFF
--- a/Bedrock.Framework/Protocols/Protocol.cs
+++ b/Bedrock.Framework/Protocols/Protocol.cs
@@ -9,10 +9,10 @@ namespace Bedrock.Framework.Protocols
 {
     public static class Protocol 
     {
-        public static ProtocolWriter<TWriteMessage> WriteProtocol<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
+        public static ProtocolWriter<TWriteMessage> CreateWriter<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
             => new ProtocolWriter<TWriteMessage>(connection, writer);
 
-        public static ProtocolReader<TReadMessage> ReadProtocol<TReadMessage>(this ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize = null)
+        public static ProtocolReader<TReadMessage> CreateReader<TReadMessage>(this ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize = null)
             => new ProtocolReader<TReadMessage>(connection, reader, maximumMessageSize);
     }
 

--- a/Bedrock.Framework/Protocols/Protocol.cs
+++ b/Bedrock.Framework/Protocols/Protocol.cs
@@ -1,27 +1,58 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 
 namespace Bedrock.Framework.Protocols
 {
-    public class Protocol<TReader, TWriter, TReadMessage, TWriteMessage> where TReader : IProtocolReader<TReadMessage>
-                                                                         where TWriter : IProtocolWriter<TWriteMessage>
+    public static class Protocol 
     {
-        private readonly TReader _reader;
-        private readonly TWriter _writer;
-        private readonly int? _maximumMessageSize;
-        private SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        public static ProtocolWriter<TWriteMessage> WriteProtocol<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
+            => new ProtocolWriter<TWriteMessage>(connection, writer);
 
-        public Protocol(ConnectionContext connection, TReader reader, TWriter writer, int? maximumMessageSize)
+        public static ProtocolReader<TReadMessage> ReadProtocol<TReadMessage>(this ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize = null)
+            => new ProtocolReader<TReadMessage>(connection, reader, maximumMessageSize);
+    }
+
+    public class ProtocolWriter<TWriteMessage>
+    {
+        private readonly IProtocolWriter<TWriteMessage> _writer;
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        public ProtocolWriter(ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
+        {
+            Connection = connection;
+            _writer = writer;
+        }
+
+        public ConnectionContext Connection { get; }
+               
+        public async ValueTask WriteAsync(TWriteMessage protocolMessage, CancellationToken cancellationToken = default)
+        {
+            await _semaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                _writer.WriteMessage(protocolMessage, Connection.Transport.Output);
+                await Connection.Transport.Output.FlushAsync(cancellationToken);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+
+    public class ProtocolReader<TReadMessage> 
+    {
+        private readonly IProtocolReader<TReadMessage> _reader;
+        private readonly int? _maximumMessageSize;
+
+        public ProtocolReader(ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize)
         {
             Connection = connection;
             _reader = reader;
-            _writer = writer;
             _maximumMessageSize = maximumMessageSize;
         }
 
@@ -110,26 +141,6 @@ namespace Bedrock.Framework.Protocols
             }
 
             return protocolMessage;
-        }
-
-        public async ValueTask WriteAsync(TWriteMessage protocolMessage, CancellationToken cancellationToken = default)
-        {
-            await _semaphore.WaitAsync(cancellationToken);
-
-            try
-            {
-                _writer.WriteMessage(protocolMessage, Connection.Transport.Output);
-                await Connection.Transport.Output.FlushAsync(cancellationToken);
-            }
-            finally
-            {
-                _semaphore.Release();
-            }
-        }
-
-        public static Protocol<TReader, TWriter, TReadMessage, TWriteMessage> Create(ConnectionContext connection, TReader reader, TWriter writer, int? maxMessageSize = null)
-        {
-            return new Protocol<TReader, TWriter, TReadMessage, TWriteMessage>(connection, reader, writer, maxMessageSize);
         }
     }
 


### PR DESCRIPTION
+ less generics 
+ more flexibility for protocol negotiation.
(for example in mqtt I need to read the beginning of the connect packet to know what version is used, right now there is a indirection that I hope to remove)

- with this pattern one could try to create multiple writers making the semaphore in the writer useless. 

sample usage:

https://github.com/JanEggers/MQTTnet/blob/5281e5316451b51b739ab229b9e8b2b911f67319/Source/MQTTnet.AspnetCore/Extensions/ConnectionContextExtensions.cs#L11-L18

https://github.com/JanEggers/MQTTnet/blob/5281e5316451b51b739ab229b9e8b2b911f67319/Source/MQTTnet.AspnetCore/MqttConnectionHandler.cs#L29-L32


