### PR TITLE
allow multiple writers and batch writes

### DIFF
--- a/Bedrock.Framework/Protocols/Protocol.cs
+++ b/Bedrock.Framework/Protocols/Protocol.cs
@@ -11,6 +11,8 @@ namespace Bedrock.Framework.Protocols
     {
         public static ProtocolWriter<TWriteMessage> CreateWriter<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
             => new ProtocolWriter<TWriteMessage>(connection, writer);
+        public static ProtocolWriter<TWriteMessage> CreateWriter<TWriteMessage>(this ConnectionContext connection, IProtocolWriter<TWriteMessage> writer, SemaphoreSlim semaphore)
+            => new ProtocolWriter<TWriteMessage>(connection, writer, semaphore);
 
         public static ProtocolReader<TReadMessage> CreateReader<TReadMessage>(this ConnectionContext connection, IProtocolReader<TReadMessage> reader, int? maximumMessageSize = null)
             => new ProtocolReader<TReadMessage>(connection, reader, maximumMessageSize);
@@ -19,11 +21,18 @@ namespace Bedrock.Framework.Protocols
     public class ProtocolWriter<TWriteMessage>
     {
         private readonly IProtocolWriter<TWriteMessage> _writer;
-        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _semaphore;
+
         public ProtocolWriter(ConnectionContext connection, IProtocolWriter<TWriteMessage> writer)
+            : this(connection, writer, new SemaphoreSlim(1))
+        {
+        }
+
+        public ProtocolWriter(ConnectionContext connection, IProtocolWriter<TWriteMessage> writer, SemaphoreSlim semaphore)
         {
             Connection = connection;
             _writer = writer;
+            _semaphore = semaphore;
         }
 
         public ConnectionContext Connection { get; }


### PR DESCRIPTION
multiple writers:
 im using MqttFrame in the server as 'raw' msg and MqttPacket base as a structured msg
the idea is to forward the raw msgs as raw as possible to avoid serialization costs and in case I need to send a heardbeat or response I use the structured msg. Having multiple classes as msgs requires multiple writers that share the same semaphore.

batching:
when sending all msgs in one chunk instead of each on its own I get a 30% boost in throughput in the benchmark. 10000 msgs 10ms => 7ms

interesting: this seems to benifit only the client when I try to batch msgs on the server before sending them out perf gets worse.


